### PR TITLE
Fix feed scheduling and model timestamp defaults

### DIFF
--- a/backend/app/feeds/base.py
+++ b/backend/app/feeds/base.py
@@ -57,35 +57,56 @@ class BaseFeed(ABC):
 
         This method should be run as an asyncio Task.
         """
+        # Ensure we can cancel the currently running task even when run() is
+        # scheduled outside of ``start`` (e.g., directly in tests).
+        if self._task is None:
+            self._task = asyncio.current_task()
+
         self._running = True
         interval = self.config.get("interval_sec", 5)
 
         self.logger.info(f"Starting feed {self.feed_id} with interval {interval}s")
 
-        while self._running:
-            try:
-                # Fetch data from source
-                payload = await self.fetch_data()
+        try:
+            while self._running:
+                # Sleep between iterations so cancellation stops before the next
+                # publish when stop() is called mid-sleep.
+                try:
+                    await asyncio.sleep(interval)
+                except asyncio.CancelledError:
+                    self.logger.info(f"Feed {self.feed_id} cancelled")
+                    break
 
-                # Publish event to hub
-                await self.hub.publish_feed_event(self.feed_id, payload)
+                if not self._running:
+                    break
 
-                # Wait for next interval
-                await asyncio.sleep(interval)
+                try:
+                    # Fetch data from source
+                    payload = await self.fetch_data()
 
-            except asyncio.CancelledError:
-                self.logger.info(f"Feed {self.feed_id} cancelled")
-                break
-            except Exception as e:
-                self.logger.error(f"Error in feed {self.feed_id}: {e}", exc_info=True)
-                # Continue running despite errors, wait before retry
-                await asyncio.sleep(interval)
+                    if not self._running:
+                        break
 
-        self.logger.info(f"Feed {self.feed_id} stopped")
+                    # Publish event to hub
+                    await self.hub.publish_feed_event(self.feed_id, payload)
+
+                except asyncio.CancelledError:
+                    self.logger.info(f"Feed {self.feed_id} cancelled")
+                    break
+                except Exception as e:
+                    self.logger.error(
+                        f"Error in feed {self.feed_id}: {e}", exc_info=True
+                    )
+                    # Continue running despite errors, wait before retry
+                    continue
+        finally:
+            self._running = False
+            self.logger.info(f"Feed {self.feed_id} stopped")
 
     async def start(self) -> None:
         """Start the feed as an asyncio Task."""
         if self._task is None or self._task.done():
+            self._running = True
             self._task = asyncio.create_task(self.run())
             self.logger.info(f"Feed {self.feed_id} task started")
 
@@ -98,6 +119,7 @@ class BaseFeed(ABC):
                 await self._task
             except asyncio.CancelledError:
                 pass
+        self._task = None
         self.logger.info(f"Feed {self.feed_id} stopped")
 
     def is_running(self) -> bool:

--- a/backend/app/models/dashboard.py
+++ b/backend/app/models/dashboard.py
@@ -25,10 +25,14 @@ class Dashboard(DashboardBase, table=True):
 
     id: UUID = SQLField(default_factory=uuid4, primary_key=True)
     created_at: datetime = SQLField(
-        sa_column=Column(DateTime(timezone=True), server_default=func.now())
+        default_factory=datetime.utcnow,
+        sa_column=Column(DateTime(timezone=True), server_default=func.now()),
     )
     updated_at: datetime = SQLField(
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+        default_factory=datetime.utcnow,
+        sa_column=Column(
+            DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+        ),
     )
 
     # Relationship to panels

--- a/backend/app/models/feed.py
+++ b/backend/app/models/feed.py
@@ -26,10 +26,14 @@ class FeedDefinition(FeedDefinitionBase, table=True):
 
     id: UUID = SQLField(default_factory=uuid4, primary_key=True)
     created_at: datetime = SQLField(
-        sa_column=Column(DateTime(timezone=True), server_default=func.now())
+        default_factory=datetime.utcnow,
+        sa_column=Column(DateTime(timezone=True), server_default=func.now()),
     )
     updated_at: datetime = SQLField(
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+        default_factory=datetime.utcnow,
+        sa_column=Column(
+            DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- add default timestamp factories to dashboard and feed models to satisfy validation during creation
- rework BaseFeed run loop to be cancellation-aware and to respect interval pacing

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691be8baebe88333bd9a1c5e7666a64d)