### PR TITLE
Fix model defaults and stabilize feed runtime

### DIFF
--- a/backend/app/models/dashboard.py
+++ b/backend/app/models/dashboard.py
@@ -2,7 +2,7 @@
 Dashboard database models and schemas.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional
 from uuid import UUID, uuid4
 
@@ -25,10 +25,12 @@ class Dashboard(DashboardBase, table=True):
 
     id: UUID = SQLField(default_factory=uuid4, primary_key=True)
     created_at: datetime = SQLField(
-        sa_column=Column(DateTime(timezone=True), server_default=func.now())
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), server_default=func.now()),
     )
     updated_at: datetime = SQLField(
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now()),
     )
 
     # Relationship to panels

--- a/backend/app/models/feed.py
+++ b/backend/app/models/feed.py
@@ -2,7 +2,7 @@
 Feed definition database models and schemas.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID, uuid4
 
@@ -26,10 +26,12 @@ class FeedDefinition(FeedDefinitionBase, table=True):
 
     id: UUID = SQLField(default_factory=uuid4, primary_key=True)
     created_at: datetime = SQLField(
-        sa_column=Column(DateTime(timezone=True), server_default=func.now())
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), server_default=func.now()),
     )
     updated_at: datetime = SQLField(
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now()),
     )
 
 


### PR DESCRIPTION
## Summary
- add timezone-aware default factories for dashboard and feed timestamps to satisfy validation
- wire websocket dashboard endpoint to dependency-injected session and hub for tests and runtime consistency
- refine BaseFeed lifecycle to start marked running earlier and honor graceful stop semantics without extra iterations

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c0217c7988333b2ddde503bbd1c6b)