### PR TITLE
Sync the agent map, Codex adapter and README to the merged Desk stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,16 @@
-# Working on Pulseboard
+# Working on Pulseboard (Codex adapter)
 
-The primary product direction is now the operations Desk in `observatory/`.
-Read `observatory/docs/DESK_ARCHITECTURE.md` and `DESK_BRIDGES.md` before changing
-measurement or data boundaries. The FastAPI / Vue workbench remains separate;
-its existing guidance in `CLAUDE.md` and `WORKBENCH.md` still applies to that code.
+`CLAUDE.md` is the canon for every agent runtime: what the two runtimes are, how to run and prove
+each seam, the map, the pitfalls and the authority (T2, `.agent-harness/tier.json`,
+`HUMAN_TODO.md`). Read it first; this file only carries what Codex needs beyond it.
 
-Run `cd observatory && npm test`. Browser changes also need
-`tests/desk-browser.py` against the real local server. The explicit offline mode
-is useful in restricted environments but does not verify HTTP serving or CSP.
-Keep the existing kit suite intact. Do not use a successful Desk gate to claim
-that legacy workbench issues #13 and #14 have been repaired.
-
-Collection is disabled by default. Do not enable collection, merge dependent PRs,
-deploy Workers, broaden probe targets or publish private projections as incidental
-cleanup. Review-only exports must stay review-only. Imported claims never become
-verified CI, user identity, public project health or causality by relabelling.
-
-Use closed, versioned contracts, bounded payloads, explicit missingness and source
-times. Preserve denominator meaning. Never average percentiles. Keep demo fixtures
-out of collector storage. Prefer a tested vertical slice to speculative scaffolding.
+- Desk changes: `cd observatory && npm test`, and for browser changes `tests/desk-browser.py`
+  against the real local server (the offline mode does not verify HTTP serving or CSP).
+- Do not enable collection, deploy Workers, broaden probe targets or publish private projections
+  as incidental cleanup. Review-only exports stay review-only. Imported claims never become
+  verified CI, user identity, public project health or causality by relabelling.
+- Closed versioned contracts, bounded payloads, explicit missingness and source times; never
+  average percentiles; demo fixtures never reach collector storage; a tested vertical slice
+  beats scaffolding. A green Desk gate never closes the workbench debt in #13 and #14.
+- Codex-specific: paths in `CLAUDE.md` are Windows (`venv/Scripts/python`); on Linux use
+  `venv/bin/python`. Codex cloud has no Playwright browser unless installed as above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,18 +4,18 @@ Pulseboard is a public GPL-3.0-only repository carrying two runtimes side by sid
 **workbench** on `main` is a FastAPI + Vue 3 real-time feed dashboard (pluggable feeds →
 WebSocket → ECharts panels). The **Desk** in `observatory/` is the new primary direction: a
 dependency-free Node collector, an aggregate read model and an operations desk, with collection
-disabled by default. As of 2026-09-10 the Desk exists only on the stacked PRs #15 → #16 → #17
-(`feat/portfolio-observatory-kit` → `feat/pulseboard-desk` → `feat/pulseboard-desk-ui`); issues
-#18–#24 are its delivery order and every one of them depends on that stack. Whether the stack
-merges at all is the owner's call (HUMAN_TODO q-3); once authorised, merge it oldest-first and
-retarget each child after its base lands (#27 tracks the post-merge doc sync).
+disabled by default. The Desk landed on `main` on 2026-09-10 through PRs #15 → #16 → #17 after a
+three-region adversarial review and fix round; issues #18–#24 are its delivery order, #31 regenerates
+the host-repo artifacts, and #32/#33 hold the tracked low findings. `AGENTS.md` is the thin Codex
+adapter of this file; `WORKBENCH.md` is the legacy runtime's user README.
 
 ## Run it (Kraspyon, measured 2026-09-10: Python 3.13, Node 24.19, no Docker Desktop)
 
 - Workbench backend: `python -m venv venv && venv/Scripts/python -m pip install -r backend/requirements.txt`,
   then `cd backend && ../venv/Scripts/python -m uvicorn app.main:app --reload --port 8000`.
 - Workbench frontend: `cd frontend/pulseboard-web && npm ci && npm run dev` → http://localhost:5173.
-- Desk (stack only): `cd observatory && npm start` → http://127.0.0.1:8788, read token printed to the terminal.
+- Desk: `cd observatory && npm start` → http://127.0.0.1:8788; the read token is printed only when generated
+  (set `READ_TOKEN`, at least 32 characters, to supply your own).
 
 ## Prove it — narrowest check per seam
 
@@ -25,15 +25,16 @@ retarget each child after its base lands (#27 tracks the post-merge doc sync).
 | backend lint/types | `cd backend && ../venv/Scripts/python -m ruff check app` and `-m mypy app` | 19 and 9 errors, pre-existing (#13) |
 | `frontend/**` | `cd frontend/pulseboard-web && npx vitest run --maxWorkers=2` | 56 passed, 2 failed, pre-existing (#13), 17 s |
 | frontend build | `cd frontend/pulseboard-web && npm run build` | fails: Tailwind `theme.css` missing (#13) |
-| `observatory/**` | `cd observatory && npm test` | 94/96 on Node 24 here (#25); 96/96 in CI on Node 22 |
-| Desk browser | `.github/workflows/desk-browser.yml`, Playwright against the real server | hosted-only; local runs need a Playwright venv |
+| `observatory/**` | `cd observatory && npm test` | 125 passed, under 1 s; CRLF-safe since #15 (#25 was line endings, not Node 24) |
+| Desk browser | `python -m venv .browser-venv && .browser-venv/Scripts/pip install playwright==1.57.0 && .browser-venv/Scripts/playwright install chromium`, then with `READ_TOKEN` exported in the foreground shell start `node src/local.mjs` and run `.browser-venv/Scripts/python tests/desk-browser.py --origin http://127.0.0.1:8788` | 13 checks passed; `kill` does not stop node.exe here, free port 8788 via PowerShell `Stop-Process` |
 | docs and harness | `git diff --check` (working tree) and `git diff --check origin/main...HEAD` (review range; `--cached` for staged); `python <agent-harness>/harness.py audit .` | clean |
 
 The red gates above are tracked debt (#13 lint/types/tests/build, #14 setuptools floor). A change
 that touches a seam must not move its numbers the wrong way, and a green Desk run never closes
-#13 or #14. CI on the stack: `observatory.yml` (Node 22, `npm test`) and `desk-browser.yml` run
-only for `observatory/**` changes. `main` has no branch protection and no workflow (measured
-2026-09-10). Squash merge is disabled repo-side; merge with a merge commit.
+#13 or #14. CI: `observatory.yml` (Node 22, `npm test`) and `desk-browser.yml` (Playwright against
+the real server) run on PRs and `main` pushes that touch `observatory/**`; nothing runs for the
+workbench. `main` has no branch protection (measured 2026-09-10). Squash merge is disabled
+repo-side; merge with a merge commit.
 
 ## Map
 
@@ -41,7 +42,7 @@ only for `observatory/**` changes. `main` has no branch protection and no workfl
   per-dashboard broadcast), `ws/` (`/ws/dashboards/{id}`), `models/` (SQLModel), `api/`.
 - `frontend/pulseboard-web/src/` — Pinia stores (`dashboards`, `liveData`, `ui`), the
   `useDashboardWebSocket` composable, `components/panels/*.vue` (ECharts).
-- `observatory/` (stack) — `src/` collector, worker, sqlite, portfolio, contracts; `public/` the Desk
+- `observatory/` — `src/` collector, worker, sqlite, portfolio, contracts; `public/` the Desk
   UI (native ESM, no build step); `adapters/` embed installer; `docs/DESK_*.md` architecture,
   bridges and direction; `tests/*.test.mjs` plus `tests/desk-browser.py`.
 - Workbench architecture detail loads by path from `.claude/rules/workbench.md`.
@@ -59,6 +60,8 @@ measurement or data boundary. Prefer a tested vertical slice to scaffolding.
 
 - `git show <ref>:path/with/slashes` under the Bash tool needs `MSYS_NO_PATHCONV=1`, or the path is mangled.
 - `venv/`, `node_modules/` and `*.db` are gitignored and absent in a fresh worktree; install before proving.
+- `observatory/` is `eol=lf` by `.gitattributes`; the rest of the tree is not, so builders that read
+  sources must normalise line endings (the embed builder does since #15).
 - Paths above are Windows (`venv/Scripts/python`); on Linux or macOS, including Codex cloud, use `venv/bin/python`.
 - `npm ci` in the frontend reports 27 audit findings (#13); triage individually, never `audit fix --force`.
 - `STATUS.md`, `DEMO_GUIDE.md`, `IMPROVEMENT_PROPOSALS.md` and `UI_IMPROVEMENTS.md` describe the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ adapter of this file; `WORKBENCH.md` is the legacy runtime's user README.
 | `frontend/**` | `cd frontend/pulseboard-web && npx vitest run --maxWorkers=2` | 56 passed, 2 failed, pre-existing (#13), 17 s |
 | frontend build | `cd frontend/pulseboard-web && npm run build` | fails: Tailwind `theme.css` missing (#13) |
 | `observatory/**` | `cd observatory && npm test` | 125 passed, under 1 s; CRLF-safe since #15 (#25 was line endings, not Node 24) |
-| Desk browser | `python -m venv .browser-venv && .browser-venv/Scripts/pip install playwright==1.57.0 && .browser-venv/Scripts/playwright install chromium`, then with `READ_TOKEN` exported in the foreground shell start `node src/local.mjs` and run `.browser-venv/Scripts/python tests/desk-browser.py --origin http://127.0.0.1:8788` | 13 checks passed; `kill` does not stop node.exe here, free port 8788 via PowerShell `Stop-Process` |
+| Desk browser | once: `python -m venv .browser-venv && .browser-venv/Scripts/pip install playwright==1.57.0 && .browser-venv/Scripts/playwright install chromium`; then, with `READ_TOKEN` exported in the foreground shell, `cd observatory && node src/local.mjs` in one shell and `cd observatory && ../.browser-venv/Scripts/python tests/desk-browser.py --origin http://127.0.0.1:8788` in another | 13 checks passed; `kill` does not stop node.exe here, free port 8788 via PowerShell `Stop-Process` |
 | docs and harness | `git diff --check` (working tree) and `git diff --check origin/main...HEAD` (review range; `--cached` for staged); `python <agent-harness>/harness.py audit .` | clean |
 
 The red gates above are tracked debt (#13 lint/types/tests/build, #14 setuptools floor). A change

--- a/README.md
+++ b/README.md
@@ -29,10 +29,8 @@ Open `http://127.0.0.1:8788`. Choose **Try a scenario** for an invented, interac
 portfolio, or paste the read token printed in your terminal to inspect the local
 collector. A clean database has no production evidence. Collection stays disabled.
 
-During review, check out `feat/pulseboard-desk-ui` rather than expecting this new
-surface on main. Review and merge the stacked changes in order: #15, #16, then
-the Desk UI PR. Retarget each dependent PR to main after its base is merged and
-rerun its checks. Do not merge a child into its unmerged feature-branch base.
+The Desk is on `main` since 2026-09-10 (PRs #15, #16 and #17, reviewed and merged in order).
+Issues #18–#24 are its delivery order; nothing is deployed and collection stays disabled.
 
 ## What is here
 


### PR DESCRIPTION
Closes #27. Documentation-only, written after #15, #16 and #17 merged to main on 2026-09-10.

- CLAUDE.md: the intro no longer says the Desk exists only on the stack; the proving table records the real observatory numbers (125 tests, CRLF-safe since #15, #25 corrected to line endings), the local recipe for the real-browser gate, and that both Desk workflows now run on main pushes. A pitfall line records that only observatory/ is eol=lf. 77 lines (T2 cap 100).
- AGENTS.md: now the thin Codex adapter of CLAUDE.md (16 lines) carrying only the Desk boundaries Codex must not cross and the POSIX-path delta, instead of a parallel guidance file with a stale merge-order sentence.
- README.md: the paragraph telling readers to check out feat/pulseboard-desk-ui and merge the stack in order is replaced by the merged state.

Verified: harness.py audit reads T2 with no findings (the missing-AGENTS.md finding is gone), git diff --check clean. Not verified: nothing executable changed.