### PR TITLE
Untrack the Vite cache and cover staged and range whitespace in the agent check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ yarn-error.log*
 .pnpm-debug.log*
 dist/
 dist-ssr/
+.vite/
 *.local
 
 # IDEs

--- a/.vite/deps/_metadata.json
+++ b/.vite/deps/_metadata.json
@@ -1,8 +1,0 @@
-{
-  "hash": "eedb27b4",
-  "configHash": "680bb27f",
-  "lockfileHash": "e3b0c442",
-  "browserHash": "78c49cf2",
-  "optimized": {},
-  "chunks": {}
-}

--- a/.vite/deps/package.json
+++ b/.vite/deps/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}

--- a/scripts/agent/check.ps1
+++ b/scripts/agent/check.ps1
@@ -1,4 +1,10 @@
-param([string]$HarnessRoot = (Join-Path $PSScriptRoot '../../../agent-harness'))
+param(
+    [string]$HarnessRoot = (Join-Path $PSScriptRoot '../../../agent-harness'),
+    # Review-range base for the third whitespace check. It must already be
+    # fetched in this checkout; on a branch whose origin/main is missing the
+    # range check fails rather than silently passing.
+    [string]$Base = 'origin/main'
+)
 $ErrorActionPreference = 'Stop'
 $repoRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
 $harness = Join-Path ([IO.Path]::GetFullPath($HarnessRoot)) 'harness.py'
@@ -6,7 +12,11 @@ if (-not (Test-Path -LiteralPath $harness)) { throw 'Pass -HarnessRoot with the 
 Push-Location $repoRoot
 try {
     git diff --check
-    if ($LASTEXITCODE -ne 0) { throw 'Whitespace check failed' }
+    if ($LASTEXITCODE -ne 0) { throw 'Whitespace check failed: working tree (git diff --check)' }
+    git diff --check --cached
+    if ($LASTEXITCODE -ne 0) { throw 'Whitespace check failed: staged changes (git diff --check --cached)' }
+    git diff --check "$Base...HEAD"
+    if ($LASTEXITCODE -ne 0) { throw "Whitespace check failed: review range (git diff --check $Base...HEAD)" }
     python $harness audit $repoRoot
     if ($LASTEXITCODE -ne 0) { throw 'Harness audit failed' }
     Push-Location 'observatory'


### PR DESCRIPTION
Two small hygiene fixes, one commit each.

## Untrack the Vite cache (#26)

`.vite/deps/_metadata.json` and `.vite/deps/package.json` were tracked at the repo root. They are
generated output that Vite rewrites on every dev run, so they produced spurious diffs. `git rm -r
--cached .vite` removes them from the index, and `.vite/` joins the other build-output entries in
the root `.gitignore` (`dist/`, `dist-ssr/`). Nothing is deleted from anyone's working tree.

`git ls-files | grep -c "^\.vite/"` is `0` on this branch.

## Cover staged and range whitespace in the agent check (#38)

`scripts/agent/check.ps1` ran only `git diff --check`, so whitespace that was staged, or already
committed on the branch, passed the proving command and surfaced later in review. It now runs three
checks in order, each throwing with a message naming which one failed:

1. `git diff --check` — working tree
2. `git diff --check --cached` — staged
3. `git diff --check "$Base...HEAD"` — review range

`-Base` is a new string parameter defaulting to `origin/main`, with a comment on the param block
noting that the base must already be fetched in the checkout: on a branch whose `origin/main` is
missing, the range check fails rather than silently passing. Existing style is unchanged —
`$ErrorActionPreference = 'Stop'`, the `Push-Location`/`finally` pairs, `$LASTEXITCODE` guards.

The `docs and harness` row of the CLAUDE.md "Prove it" table names `git diff --check` and the
harness audit, not `check.ps1`, and it already lists all three whitespace forms, so it stays correct
and is untouched.

## Proof

Run from the worktree root, on the branch head:

- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/agent/check.ps1 -HarnessRoot <agent-harness>`
  — passes: `[ok] harness audit`, then the Desk suite at `tests 125 / pass 125 / fail 0`
  (`npm ci` in `observatory/` first; `node_modules` is gitignored and absent in a fresh worktree).
- Negative test of the new staged check: wrote `ws-probe.txt` with a trailing-whitespace line and
  `git add`ed it, then reran the script. It stopped at the second check with
  `Whitespace check failed: staged changes (git diff --check --cached)` — before the harness audit
  and before the tests, which is the intended ordering. The old script passed this same state. The
  probe file was then removed and the tree is clean.
- `git diff --check origin/main...HEAD` — clean.

Not verified: the workbench frontend and backend seams are untouched by this branch, so their
pre-existing red gates (#13, #14) were not run and are unchanged. Those two remain open.

Closes #26
Closes #38
